### PR TITLE
Next version v0.0.2

### DIFF
--- a/.github-scheduled-workflows/publish-main.yaml
+++ b/.github-scheduled-workflows/publish-main.yaml
@@ -47,6 +47,6 @@ jobs:
           token: ${{ secrets.PAT_TOKEN }}   
           changes: |
             {
-              "replaces": "gingersnap-operator.v${{ env.replace_version }}"
+              "replaces": "gingersnap.v${{ env.replace_version }}"
             }
           

--- a/config/manifests/bases/gingersnap-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/gingersnap-operator.clusterserviceversion.yaml
@@ -57,4 +57,5 @@ spec:
   minKubeVersion: 1.23.5
   provider:
     name: Gingersnap
+  replaces: gingersnap.v0.0.1
   version: 0.0.0


### PR DESCRIPTION
@pminz I'm manually adding the `replaces` field to the CSV as discussed. It's also necessary for the GH action to be updated as we now use a different OLM bundle format to what we originally planned, hence the new name.